### PR TITLE
Fix pie chart values

### DIFF
--- a/ci/templates/ci/dashboard.html
+++ b/ci/templates/ci/dashboard.html
@@ -184,7 +184,10 @@
     metrics(widget)
       .forEach(function(d) {
         if (widget['type'] == 'pie'){
-          d.value = data[d.key].length > 0 ? data[d.key][data[d.key].length-1].y : 0;
+          d.value = 0;
+          data[d.key].forEach(function(v) {
+            d.value += v.y
+          })
         } else {
           d.values = data[d.key];
         }


### PR DESCRIPTION
Previously pie charts were only displaying the value for the last interval returned for a metric. The expected behaviour was for it to display the sum over all of the intervals returned.
eg
If a metric returns `[{y: 35, x: 1473984000000}, {y: 3, x: 1474243200000}]` the pie chart should display 38 for that metric. Previously that was displaying 3.
