### PR TITLE
Feature/fix past day estimates

### DIFF
--- a/ci/utils.py
+++ b/ci/utils.py
@@ -26,12 +26,12 @@ def transform_timeseries_data(timeseries, start, end=None):
 
 
 def get_last_value_from_timeseries(timeseries):
-    """Gets the most recent value for a .last metric or zero for empty data."""
+    """Gets the most recent non-zero value for a .last metric or zero
+    for empty data."""
     if not timeseries:
         return 0
     for metric, points in timeseries.items():
-        point = points.pop()
-        return point['y']
+        return next((p['y'] for p in reversed(points) if p['y'] > 0), 0)
 
 
 def get_timestamp(dt):

--- a/ci/views.py
+++ b/ci/views.py
@@ -254,7 +254,7 @@ def health_messages(request):
             for day in range(7):
                 estimated = client.get_metric(
                     'subscriptions.send.estimate.%s.last' % day,
-                    '-1d', '1d', 'zeroize')
+                    '-7d', '1d', 'zeroize')
                 estimate_data.append(
                     utils.get_last_value_from_timeseries(estimated))
             return JsonResponse({


### PR DESCRIPTION
Because estimate metrics are not updated during the week for days that have already passed, we need to get the last non-zero value from the past week of values.