### PR TITLE
Fix subscription lookup filter

### DIFF
--- a/ci/management/commands/generate_reports.py
+++ b/ci/management/commands/generate_reports.py
@@ -513,7 +513,7 @@ class Command(BaseCommand):
                 # Get the last subscription before the optout that is inactive
                 subscriptions = list(self.get_subscriptions(
                     sbm_client, identity=optout['identity'],
-                    created_to=optout['created_at'],
+                    created_before=optout['created_at'],
                     active=False, completed=False))
                 subscriptions.sort(key=lambda s: s['created_at'], reverse=True)
                 try:

--- a/ci/tests.py
+++ b/ci/tests.py
@@ -621,7 +621,7 @@ class GenerateReportTest(TestCase):
         self.add_subscriptions_callback(
             path=(
                 '?active=False&completed=False&'
-                'created_to=2017-01-27T10%3A00%3A06.354178Z&'
+                'created_before=2017-01-27T10%3A00%3A06.354178Z&'
                 'identity=8311c23d-f3c4-4cab-9e20-5208d77dcd1b')
         )
 


### PR DESCRIPTION
For the optouts by subscription report, the loopup filter for the list of subscriptions is using `created_to` instead of `created_before`.