### PR TITLE
Catch connection errors when submitting reports

### DIFF
--- a/ci/templates/ci/reports.html
+++ b/ci/templates/ci/reports.html
@@ -18,11 +18,15 @@
 <hr class="m-t">
 
 {% if messages %}
-<div class="alert alert-success" role="alert">
-    {% for message in messages %}
-    <p{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</p>
-    {% endfor %}
-</div>
+  {% for message in messages %}
+    {% if message.tags == 'error' %}
+      <div class="alert alert-danger" role="alert">
+    {% else %}
+      <div class="alert alert-success" role="alert">
+    {% endif%}
+        <p class="{{ message.tags }}">{{ message }}</p>
+    </div>
+  {% endfor %}
 {% endif %}
 
 <div class="row">


### PR DESCRIPTION
This PR displays an error if there's an issue submitting the report request.
Errors were being displayed as success alerts so they looked green and shiny instead of red and angry