### PR TITLE
Add setting for where to find language on identity

### DIFF
--- a/ci/views.py
+++ b/ci/views.py
@@ -519,16 +519,16 @@ def identity(request, identity):
     if request.method == "POST":
         if 'add_subscription' in request.POST:
             form = AddSubscriptionForm(request.POST)
+            language = results['details'].get(settings.LANGUAGE_FIELD)
 
-            if results['details'].get('preferred_language'):
+            if language:
 
                 if form.is_valid():
                     subscription = {
                         "active": True,
                         "identity": identity,
                         "completed": False,
-                        "lang":
-                            results['details'].get('preferred_language'),
+                        "lang": language,
                         "messageset": form.cleaned_data['messageset'],
                         "next_sequence_number": 1,
                         "schedule":
@@ -547,7 +547,8 @@ def identity(request, identity):
                 messages.add_message(
                     request,
                     messages.ERROR,
-                    'No preferred language on the identity.',
+                    'No language value in {} on the identity.'.format(
+                        settings.LANGUAGE_FIELD),
                     extra_tags='danger'
                 )
 

--- a/seed_control_interface/settings.py
+++ b/seed_control_interface/settings.py
@@ -169,6 +169,7 @@ IDENTITY_STORE_TOKEN = os.environ.get(
 
 IDENTITY_FIELD = os.environ.get('IDENTITY_FIELD', 'mother_id')
 STAGE_FIELD = os.environ.get('STAGE_FIELD', 'stage')
+LANGUAGE_FIELD = os.environ.get('LANGUAGE_FIELD', 'preferred_language')
 _stage_string = os.environ.get(
     'STAGES',
     'prebirth:Mother is pregnant,postbirth:Baby has been born,loss:Baby loss')


### PR DESCRIPTION
Different registration services put the language field in different places on the identity, but when creating a new subscription for an identity, the CI assumes that the language field is `preferred_language`.

This PR allows the field location to be set as a setting.